### PR TITLE
Fix error with chrome driver

### DIFF
--- a/src/main/java/com/vtence/mario/WebElementDriver.java
+++ b/src/main/java/com/vtence/mario/WebElementDriver.java
@@ -82,6 +82,7 @@ public class WebElementDriver {
     public void click() {
         isShowingOnScreen();
         isEnabled();
+        hoverWithMouse();
         apply(ElementActions.click());
     }
 


### PR DESCRIPTION
With chrome driver, the navigator doesn't scroll to click on button, even if it's at the bottom in the page
Furthermore, the logical move of a user is to move mouse on the button before clicking on it.